### PR TITLE
Use local directory for project's reference instead of github link

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -5,9 +5,7 @@ site:
   start_page: k8s-demo::index.adoc
 content:
   sources:
-  - url: https://github.com/camptocamp/k8s-demo.git
-    branches: convert_to_asciidoc
-    #branches: [v2.0, v1.0]
+  - url: ./
     edit_url: false
     start_path: docs
 ui:


### PR DESCRIPTION
Previous uploaded version was using a github url to get the sources from, where it is not needed, since we're building the documentation site for this project. Better use local directory as a content source